### PR TITLE
Tweaks to MAVLink in dev docs

### DIFF
--- a/master/en/middleware/mavlink.html
+++ b/master/en/middleware/mavlink.html
@@ -2419,13 +2419,17 @@ Once you&apos;ve <a href="https://mavlink.io/en/getting_started/installation.htm
 <p>For your own use/testing you can just copy the generated headers into <strong>Firmware/mavlink/include/mavlink/v2.0</strong>.</p>
 <p>To make it easier for others to test your changes, a better approach is to add your generated headers to a fork of <a href="https://github.com/mavlink/c_library_v2" target="_blank">https://github.com/mavlink/c_library_v2</a>.
 PX4 developers can then update the submodule to your fork in the Firmware repo before building.</p>
+<p><b>Note:</b> MEVGEN currently has a bug where nested includes do not compile correctly. This can be read about <a href="https://github.com/ArduPilot/pymavlink/pull/339" target="_blank">here</a>. 
+The fix to this issue is to include <b>custom_messages.xml</b> in <b>ardupilotmega.xml</b> and build the libraries from <b>ardupilotmega.xml</b>.</p>
 <h2 id="sending-custom-mavlink-messages"><a name="sending-custom-mavlink-messages" class="plugin-anchor" href="#sending-custom-mavlink-messages"><i class="fa fa-link" aria-hidden="true"></i></a>Sending Custom MAVLink Messages</h2>
 <p>This section explains how to use a custom uORB message and send it as a MAVLink message.</p>
 <p>Add the headers of the MAVLink and uORB messages to
 <a href="https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_messages.cpp" target="_blank">mavlink_messages.cpp</a></p>
 <pre><code class="lang-C"><span class="hljs-meta">#<span class="hljs-meta-keyword">include</span> <span class="hljs-meta-string">&lt;uORB/topics/ca_trajectory.h&gt;</span></span>
-<span class="hljs-meta">#<span class="hljs-meta-keyword">include</span> <span class="hljs-meta-string">&lt;v2.0/custom_messages/mavlink.h&gt;</span></span>
+<span class="hljs-meta">#<span class="hljs-meta-keyword">include</span> <span class="hljs-meta-string">&lt;v2.0/custom_messages/mavlink_msg_ca_trajectory.h&gt;</span></span>
 </code></pre>
+<p><b>Note:</b> Due to an issue with inclusion check order, the following will not work.</p>
+<pre><code><span class="hljs-meta">#<span class="hljs-meta-keyword">include</span> <span class="hljs-meta-string">&lt;v2.0/custom_messages/mavlink.h&gt;</span></span></code></pre>
 <p>Create a new class in <a href="https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_messages.cpp#L2193" target="_blank">mavlink_messages.cpp</a></p>
 <pre><code class="lang-C">class MavlinkStreamCaTrajectory : public MavlinkStream
 {
@@ -2491,14 +2495,13 @@ protected:
 </code></pre>
 <p>Finally append the stream class to the <code>streams_list</code> at the bottom of
 <a href="https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_messages.cpp" target="_blank">mavlink_messages.cpp</a></p>
-<pre><code class="lang-C">StreamListItem *streams_list[] = {
+<pre><code class="lang-C">static const StreamListItem streams_list[] = {
 ...
-<span class="hljs-keyword">new</span> StreamListItem(&amp;MavlinkStreamCaTrajectory::new_instance, &amp;MavlinkStreamCaTrajectory::get_name_static, &amp;MavlinkStreamCaTrajectory::get_id_static),
-<span class="hljs-literal">nullptr</span>
+create_stream_list_item<span><</span>MavlinkStreamCaTrajectory<span>></span>()
 };
 </code></pre>
-<p>Then make sure to enable the stream, for example by adding the following line to the <a href="../concept/system_startup.html">startup script</a> (e.g. <a href="https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS" target="_blank">/ROMFS/px4fmu_common/init.d-posix/rcS</a> on NuttX or <a href="https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS" target="_blank">ROMFS/px4fmu_common/init.d-posix/rcS</a>) on SITL. Note that <code>-r</code> configures the streaming rate and <code>-u</code> identifies the MAVLink channel on UDP port 14556).</p>
-<pre><code>mavlink stream -r 50 -s CA_TRAJECTORY -u 14556
+<p>Then make sure to enable the stream, for example by adding the following line to the <a href="../concept/system_startup.html">startup script</a> (e.g. <a href="https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS" target="_blank">/ROMFS/px4fmu_common/init.d-posix/rcS</a> on NuttX or <a href="https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS" target="_blank">ROMFS/px4fmu_common/init.d-posix/rcS</a> on SITL). Note that <code>-r</code> configures the streaming rate and <code>-u</code> identifies the MAVLink channel on UDP port 14556.</p>
+<pre><code>mavlink stream -r 50 -s CA_TRAJECTORY -u $udp_gcs_port_local
 </code></pre><blockquote class="clearfix alert alert-success"><strong class="fa fa-2x fa-thumbs-o-up"></strong>
 <p> You can use the <code>uorb top [&lt;message_name&gt;]</code> command to verify in real-time that your message is published and the rate (see <a href="uorb.html#uorb-top-command">uORB Messaging</a>). 
   This approach can also be used to test incoming messages that publish a uORB topic (for other messages you might use <code>printf</code> in your code and test in SITL).</p>

--- a/v1.10/en/middleware/mavlink.html
+++ b/v1.10/en/middleware/mavlink.html
@@ -84,7 +84,7 @@
     <link rel="next" href="micrortps.html" />
     
     
-    <link rel="prev" href="uorb_graph.html" />
+    <link rel="prev" href="uorb.html" />
     
 
     </head>
@@ -336,19 +336,6 @@
             
         </li>
     
-        <li class="chapter " data-level="1.2.2.3.4" data-path="../setup/dev_env_windows_msys.html">
-            
-                <a href="../setup/dev_env_windows_msys.html">
-            
-                    
-                    Msys Toolchain
-            
-                </a>
-            
-
-            
-        </li>
-    
 
             </ul>
             
@@ -538,6 +525,25 @@
             
 
             
+            <ul class="articles">
+                
+    
+        <li class="chapter " data-level="1.3.5.1" data-path="../concept/custom_mixer_payload.html">
+            
+                <a href="../concept/custom_mixer_payload.html">
+            
+                    
+                    Custom Payload Mixer
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+            </ul>
+            
         </li>
     
         <li class="chapter " data-level="1.3.6" data-path="../concept/pwm_limit.html">
@@ -559,6 +565,19 @@
             
                     
                     System Startup
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.3.8" data-path="../concept/sd_card_layout.html">
+            
+                <a href="../concept/sd_card_layout.html">
+            
+                    
+                    SD Card Layout
             
                 </a>
             
@@ -608,6 +627,38 @@
                 </a>
             
 
+            
+            <ul class="articles">
+                
+    
+        <li class="chapter " data-level="1.4.2.1" data-path="../simulation/gazebo_vehicles.html">
+            
+                <a href="../simulation/gazebo_vehicles.html">
+            
+                    
+                    Gazebo Vehicles
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.4.2.2" data-path="../simulation/gazebo_worlds.html">
+            
+                <a href="../simulation/gazebo_worlds.html">
+            
+                    
+                    Gazebo Worlds
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+            </ul>
             
         </li>
     
@@ -731,6 +782,25 @@
                 </a>
             
 
+            
+            <ul class="articles">
+                
+    
+        <li class="chapter " data-level="1.5.2.1" data-path="../hardware/porting_guide_nuttx.html">
+            
+                <a href="../hardware/porting_guide_nuttx.html">
+            
+                    
+                    NuttX Board Porting Guide
+            
+                </a>
+            
+
+            
+        </li>
+    
+
+            </ul>
             
         </li>
     
@@ -1030,20 +1100,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.6.2" data-path="uorb_graph.html">
-            
-                <a href="uorb_graph.html">
-            
-                    
-                    uORB Graph
-            
-                </a>
-            
-
-            
-        </li>
-    
-        <li class="chapter active" data-level="1.6.3" data-path="mavlink.html">
+        <li class="chapter active" data-level="1.6.2" data-path="mavlink.html">
             
                 <a href="mavlink.html">
             
@@ -1056,7 +1113,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.6.4" data-path="micrortps.html">
+        <li class="chapter " data-level="1.6.3" data-path="micrortps.html">
             
                 <a href="micrortps.html">
             
@@ -1070,7 +1127,7 @@
             <ul class="articles">
                 
     
-        <li class="chapter " data-level="1.6.4.1" data-path="micrortps_throughput_test.html">
+        <li class="chapter " data-level="1.6.3.1" data-path="micrortps_throughput_test.html">
             
                 <a href="micrortps_throughput_test.html">
             
@@ -1083,7 +1140,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.6.4.2" data-path="micrortps_manual_code_generation.html">
+        <li class="chapter " data-level="1.6.3.2" data-path="micrortps_manual_code_generation.html">
             
                 <a href="micrortps_manual_code_generation.html">
             
@@ -1173,12 +1230,64 @@
             <ul class="articles">
                 
     
-        <li class="chapter " data-level="1.7.4.1" data-path="modules_driver_distance_sensor.html">
+        <li class="chapter " data-level="1.7.4.1" data-path="modules_driver_airspeed_sensor.html">
+            
+                <a href="modules_driver_airspeed_sensor.html">
+            
+                    
+                    Airspeed Sensor
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.7.4.2" data-path="modules_driver_baro.html">
+            
+                <a href="modules_driver_baro.html">
+            
+                    
+                    Baro
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.7.4.3" data-path="modules_driver_distance_sensor.html">
             
                 <a href="modules_driver_distance_sensor.html">
             
                     
                     Distance Sensor
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.7.4.4" data-path="modules_driver_imu.html">
+            
+                <a href="modules_driver_imu.html">
+            
+                    
+                    IMU
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.7.4.5" data-path="modules_driver_magnetometer.html">
+            
+                <a href="modules_driver_magnetometer.html">
+            
+                    
+                    Magnetometer
             
                 </a>
             
@@ -1430,7 +1539,34 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.2" data-path="../debug/system_console.html">
+        <li class="chapter " data-level="1.9.2" data-path="../debug/consoles.html">
+            
+                <a href="../debug/consoles.html">
+            
+                    
+                    Consoles/Shells
+            
+                </a>
+            
+
+            
+            <ul class="articles">
+                
+    
+        <li class="chapter " data-level="1.9.2.1" data-path="../debug/mavlink_shell.html">
+            
+                <a href="../debug/mavlink_shell.html">
+            
+                    
+                    MAVLink Shell
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.9.2.2" data-path="../debug/system_console.html">
             
                 <a href="../debug/system_console.html">
             
@@ -1443,7 +1579,25 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.3" data-path="../debug/gdb_debugging.html">
+
+            </ul>
+            
+        </li>
+    
+        <li class="chapter " data-level="1.9.3" data-path="../debug/swd_debug.html">
+            
+                <a href="../debug/swd_debug.html">
+            
+                    
+                    SWD/JLink Debug Interface
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.9.4" data-path="../debug/gdb_debugging.html">
             
                 <a href="../debug/gdb_debugging.html">
             
@@ -1456,7 +1610,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.4" data-path="../debug/eclipse_jlink.html">
+        <li class="chapter " data-level="1.9.5" data-path="../debug/eclipse_jlink.html">
             
                 <a href="../debug/eclipse_jlink.html">
             
@@ -1469,7 +1623,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.5" data-path="../debug/sensor_uorb_topic_debugging.html">
+        <li class="chapter " data-level="1.9.6" data-path="../debug/sensor_uorb_topic_debugging.html">
             
                 <a href="../debug/sensor_uorb_topic_debugging.html">
             
@@ -1482,7 +1636,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.6" data-path="../debug/simulation_debugging.html">
+        <li class="chapter " data-level="1.9.7" data-path="../debug/simulation_debugging.html">
             
                 <a href="../debug/simulation_debugging.html">
             
@@ -1495,7 +1649,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.7" data-path="../debug/debug_values.html">
+        <li class="chapter " data-level="1.9.8" data-path="../debug/debug_values.html">
             
                 <a href="../debug/debug_values.html">
             
@@ -1508,7 +1662,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.8" data-path="../debug/system_wide_replay.html">
+        <li class="chapter " data-level="1.9.9" data-path="../debug/system_wide_replay.html">
             
                 <a href="../debug/system_wide_replay.html">
             
@@ -1521,7 +1675,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.9" data-path="../debug/profiling.html">
+        <li class="chapter " data-level="1.9.10" data-path="../debug/profiling.html">
             
                 <a href="../debug/profiling.html">
             
@@ -1534,7 +1688,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.10" data-path="../log/logging.html">
+        <li class="chapter " data-level="1.9.11" data-path="../log/logging.html">
             
                 <a href="../log/logging.html">
             
@@ -1547,7 +1701,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.11" data-path="../log/flight_log_analysis.html">
+        <li class="chapter " data-level="1.9.12" data-path="../log/flight_log_analysis.html">
             
                 <a href="../log/flight_log_analysis.html">
             
@@ -1560,7 +1714,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.9.12" data-path="../log/ulog_file_format.html">
+        <li class="chapter " data-level="1.9.13" data-path="../log/ulog_file_format.html">
             
                 <a href="../log/ulog_file_format.html">
             
@@ -1610,7 +1764,7 @@
                 <a href="../qgc/video_streaming.html">
             
                     
-                    Video Streaming in QGC
+                    Video Streaming from Odroid C1 to QGC
             
                 </a>
             
@@ -1636,7 +1790,7 @@
                 <a href="../tutorials/linux_sbus.html">
             
                     
-                    S.Bus Driver for Linux
+                    Connecting an RC Receiver on Linux
             
                 </a>
             
@@ -1933,7 +2087,7 @@
                 <a href="../test_and_ci/integration_testing.html">
             
                     
-                    Integration Testing
+                    ROS Integration Testing
             
                 </a>
             
@@ -1941,7 +2095,20 @@
             
         </li>
     
-        <li class="chapter " data-level="1.12.6" data-path="../test_and_ci/docker.html">
+        <li class="chapter " data-level="1.12.6" data-path="../test_and_ci/integration_testing_mavsdk.html">
+            
+                <a href="../test_and_ci/integration_testing_mavsdk.html">
+            
+                    
+                    MAVSDK Integration Testing
+            
+                </a>
+            
+
+            
+        </li>
+    
+        <li class="chapter " data-level="1.12.7" data-path="../test_and_ci/docker.html">
             
                 <a href="../test_and_ci/docker.html">
             
@@ -1954,7 +2121,7 @@
             
         </li>
     
-        <li class="chapter " data-level="1.12.7" data-path="../test_and_ci/maintenance.html">
+        <li class="chapter " data-level="1.12.8" data-path="../test_and_ci/maintenance.html">
             
                 <a href="../test_and_ci/maintenance.html">
             
@@ -2252,13 +2419,17 @@ Once you&apos;ve <a href="https://mavlink.io/en/getting_started/installation.htm
 <p>For your own use/testing you can just copy the generated headers into <strong>Firmware/mavlink/include/mavlink/v2.0</strong>.</p>
 <p>To make it easier for others to test your changes, a better approach is to add your generated headers to a fork of <a href="https://github.com/mavlink/c_library_v2" target="_blank">https://github.com/mavlink/c_library_v2</a>.
 PX4 developers can then update the submodule to your fork in the Firmware repo before building.</p>
+<p><b>Note:</b> MEVGEN currently has a bug where nested includes do not compile correctly. This can be read about <a href="https://github.com/ArduPilot/pymavlink/pull/339" target="_blank">here</a>. 
+The fix to this issue is to include <b>custom_messages.xml</b> in <b>ardupilotmega.xml</b> and build the libraries from <b>ardupilotmega.xml</b>.</p>
 <h2 id="sending-custom-mavlink-messages"><a name="sending-custom-mavlink-messages" class="plugin-anchor" href="#sending-custom-mavlink-messages"><i class="fa fa-link" aria-hidden="true"></i></a>Sending Custom MAVLink Messages</h2>
 <p>This section explains how to use a custom uORB message and send it as a MAVLink message.</p>
 <p>Add the headers of the MAVLink and uORB messages to
 <a href="https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_messages.cpp" target="_blank">mavlink_messages.cpp</a></p>
 <pre><code class="lang-C"><span class="hljs-meta">#<span class="hljs-meta-keyword">include</span> <span class="hljs-meta-string">&lt;uORB/topics/ca_trajectory.h&gt;</span></span>
-<span class="hljs-meta">#<span class="hljs-meta-keyword">include</span> <span class="hljs-meta-string">&lt;v2.0/custom_messages/mavlink.h&gt;</span></span>
+<span class="hljs-meta">#<span class="hljs-meta-keyword">include</span> <span class="hljs-meta-string">&lt;v2.0/custom_messages/mavlink_msg_ca_trajectory.h&gt;</span></span>
 </code></pre>
+<p><b>Note:</b> Due to an issue with inclusion check order, the following will not work.</p>
+<pre><code><span class="hljs-meta">#<span class="hljs-meta-keyword">include</span> <span class="hljs-meta-string">&lt;v2.0/custom_messages/mavlink.h&gt;</span></span></code></pre>
 <p>Create a new class in <a href="https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_messages.cpp#L2193" target="_blank">mavlink_messages.cpp</a></p>
 <pre><code class="lang-C">class MavlinkStreamCaTrajectory : public MavlinkStream
 {
@@ -2324,16 +2495,13 @@ protected:
 </code></pre>
 <p>Finally append the stream class to the <code>streams_list</code> at the bottom of
 <a href="https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_messages.cpp" target="_blank">mavlink_messages.cpp</a></p>
-<pre><code class="lang-C">StreamListItem *streams_list[] = {
+<pre><code class="lang-C">static const StreamListItem streams_list[] = {
 ...
-<span class="hljs-keyword">new</span> StreamListItem(&amp;MavlinkStreamCaTrajectory::new_instance, &amp;MavlinkStreamCaTrajectory::get_name_static, &amp;MavlinkStreamCaTrajectory::get_id_static),
-<span class="hljs-literal">nullptr</span>
+create_stream_list_item<span><</span>MavlinkStreamCaTrajectory<span>></span>()
 };
 </code></pre>
-<p>Then make sure to enable the stream, for example by adding the following line to
-the startup script (<code>-r</code> configures the streaming rate, <code>-u</code> identifies the
-MAVLink channel on UDP port 14556):</p>
-<pre><code>mavlink stream -r 50 -s CA_TRAJECTORY -u 14556
+<p>Then make sure to enable the stream, for example by adding the following line to the <a href="../concept/system_startup.html">startup script</a> (e.g. <a href="https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS" target="_blank">/ROMFS/px4fmu_common/init.d-posix/rcS</a> on NuttX or <a href="https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/rcS" target="_blank">ROMFS/px4fmu_common/init.d-posix/rcS</a> on SITL). Note that <code>-r</code> configures the streaming rate and <code>-u</code> identifies the MAVLink channel on UDP port 14556.</p>
+<pre><code>mavlink stream -r 50 -s CA_TRAJECTORY -u $udp_gcs_port_local
 </code></pre><blockquote class="clearfix alert alert-success"><strong class="fa fa-2x fa-thumbs-o-up"></strong>
 <p> You can use the <code>uorb top [&lt;message_name&gt;]</code> command to verify in real-time that your message is published and the rate (see <a href="uorb.html#uorb-top-command">uORB Messaging</a>). 
   This approach can also be used to test incoming messages that publish a uORB topic (for other messages you might use <code>printf</code> in your code and test in SITL).</p>
@@ -2438,7 +2606,7 @@ An example would be:</p>
 
             
                 
-                <a href="uorb_graph.html" class="navigation navigation-prev " aria-label="Previous page: uORB Graph">
+                <a href="uorb.html" class="navigation navigation-prev " aria-label="Previous page: uORB Messaging">
                     <i class="fa fa-angle-left"></i>
                 </a>
                 
@@ -2454,7 +2622,7 @@ An example would be:</p>
     <script>
         var gitbook = gitbook || [];
         gitbook.push(function() {
-            gitbook.page.hasChanged({"page":{"title":"MAVLink Messaging","level":"1.6.3","depth":2,"next":{"title":"RTPS/ROS2 Interface","level":"1.6.4","depth":2,"path":"middleware/micrortps.md","ref":"middleware/micrortps.md","articles":[{"title":"Throughput Test","level":"1.6.4.1","depth":3,"path":"middleware/micrortps_throughput_test.md","ref":"middleware/micrortps_throughput_test.md","articles":[]},{"title":"Manually Generate Client/Agent","level":"1.6.4.2","depth":3,"path":"middleware/micrortps_manual_code_generation.md","ref":"middleware/micrortps_manual_code_generation.md","articles":[]}]},"previous":{"title":"uORB Graph","level":"1.6.2","depth":2,"path":"middleware/uorb_graph.md","ref":"middleware/uorb_graph.md","articles":[]},"dir":"ltr"},"config":{"plugins":["youtube","richquotes@git+https://github.com/Dronecode/gitbook-plugin-richquotes.git","collapsible-menu","anchors","page-toc-button","ga","language-picker","custom-favicon","bulk-redirect@git+https://github.com/Dronecode/gitbook-plugin-bulk-redirect.git","toolbar@git+https://github.com/hamishwillee/gitbook-plugin-toolbar.git","validate-links","versions-select@git+https://github.com/Dronecode/gitbook-plugin-versions-select.git","mathjax@git+https://github.com/Dronecode/plugin-mathjax.git#update_cdn","mermaid","-stub-out-blocks@git+https://github.com/hamishwillee/gitbook-plugin-stub-out-blocks.git","theme-dronecode@git+https://github.com/dronecode/theme-dronecode.git"],"styles":{"website":"styles/website.css","pdf":"styles/pdf.css","epub":"styles/epub.css","mobi":"styles/mobi.css","ebook":"styles/ebook.css","print":"styles/print.css"},"pluginsConfig":{"theme-dronecode":{"logo":{"logo_large":"gitbook-plugin-theme-dronecode/images/dronecode_top_bar_logo_full.png","logo_small":"gitbook-plugin-theme-dronecode/images/dronecode_top_bar_logo_small.png","url":"https://www.dronecode.org/"}},"validate-links":{"defaultScheme":"https","local":"warn","remote":"disabled"},"collapsible-menu":{},"language-picker":{"grid-columns":3},"youtube":{},"search":{},"mermaid":{},"lunr":{"maxIndexSize":1000000,"ignoreSpecialCharacters":false},"versions-select":{"type":"branches"},"fontsettings":{"theme":"white","family":"sans","size":2},"richquotes":{"tip":{"alert":"success","picto":"fa-thumbs-o-up"}},"highlight":{},"favicon":"favicon.ico","page-toc-button":{},"bulk-redirect":{"basepath":"/","redirectsFile":"redirects.json"},"custom-favicon":{},"mathjax":{"forceSVG":false,"version":"2.7.6"},"ga":{"configuration":"auto","token":"UA-33658859-3"},"versions":{"gitbookConfigURL":"https://raw.githubusercontent.com/PX4/Devguide/master/book.json","options":[{"value":"https://dev.px4.io/master/en/","text":"master"},{"value":"https://dev.px4.io/v1.9.0/en/","text":"1.9 - stable"},{"value":"https://dev.px4.io/v1.8.2/en/","text":"1.8.2"},{"value":"https://dev.px4.io/v1.8.0/en/","text":"1.8.0"}]},"toolbar":{"buttons":[{"label":"Bug tracker","icon":"fa fa-bug","position":"left","url":"https://github.com/PX4/Devguide/issues/new?title=Doc+Bug:+{{title}}&body=DESCRIBE+PROBLEM+WITH+DOCS+HERE%0A%0ABug+Page:+[{{title}}]({{url}})"},{"label":"GitHub","icon":"fa fa-github","url":"https://github.com/PX4/Devguide"},{"label":"Edit page on github","icon":"fa fa-pencil-square-o","position":"left","url":"https://github.com/PX4/Devguide/edit/master/{{filepath_lang}}"}]},"sharing":{"facebook":true,"twitter":true,"google":false,"weibo":false,"instapaper":false,"vk":false,"all":["facebook","google","twitter","weibo","instapaper"]},"theme-default":{"styles":{"website":"styles/website.css","pdf":"styles/pdf.css","epub":"styles/epub.css","mobi":"styles/mobi.css","ebook":"styles/ebook.css","print":"styles/print.css"},"showLevel":false},"anchors":{}},"theme":"default","pdf":{"pageNumbers":true,"fontSize":12,"fontFamily":"Arial","paperSize":"a4","chapterMark":"pagebreak","pageBreaksBefore":"/","margin":{"right":62,"left":62,"top":56,"bottom":56}},"structure":{"langs":"LANGS.md","readme":"README.md","glossary":"GLOSSARY.md","summary":"SUMMARY.md"},"variables":{"logo":"./assets/site/logo_pro_small.png","px4_version":"v1.10.0"},"title":"PX4 Developer Guide","language":"en","gitbook":"*"},"file":{"path":"middleware/mavlink.md","mtime":"2020-03-30T02:20:20.732Z","type":"markdown"},"gitbook":{"version":"3.2.3","time":"2020-03-30T02:21:22.295Z"},"basePath":"..","book":{"language":"en"}});
+            gitbook.page.hasChanged({"page":{"title":"MAVLink Messaging","level":"1.6.2","depth":2,"next":{"title":"RTPS/ROS2 Interface","level":"1.6.3","depth":2,"path":"middleware/micrortps.md","ref":"middleware/micrortps.md","articles":[{"title":"Throughput Test","level":"1.6.3.1","depth":3,"path":"middleware/micrortps_throughput_test.md","ref":"middleware/micrortps_throughput_test.md","articles":[]},{"title":"Manually Generate Client/Agent","level":"1.6.3.2","depth":3,"path":"middleware/micrortps_manual_code_generation.md","ref":"middleware/micrortps_manual_code_generation.md","articles":[]}]},"previous":{"title":"uORB Messaging","level":"1.6.1","depth":2,"path":"middleware/uorb.md","ref":"middleware/uorb.md","articles":[]},"dir":"ltr"},"config":{"plugins":["youtube","richquotes@git+https://github.com/Dronecode/gitbook-plugin-richquotes.git","collapsible-menu","anchors","page-toc-button","ga","language-picker","custom-favicon","bulk-redirect@git+https://github.com/Dronecode/gitbook-plugin-bulk-redirect.git","toolbar@git+https://github.com/hamishwillee/gitbook-plugin-toolbar.git","validate-links","versions-select@git+https://github.com/Dronecode/gitbook-plugin-versions-select.git","mathjax@git+https://github.com/Dronecode/plugin-mathjax.git#update_cdn","mermaid","-stub-out-blocks@git+https://github.com/hamishwillee/gitbook-plugin-stub-out-blocks.git","theme-dronecode@git+https://github.com/dronecode/theme-dronecode.git"],"styles":{"website":"styles/website.css","pdf":"styles/pdf.css","epub":"styles/epub.css","mobi":"styles/mobi.css","ebook":"styles/ebook.css","print":"styles/print.css"},"pluginsConfig":{"theme-dronecode":{"logo":{"logo_large":"gitbook-plugin-theme-dronecode/images/dronecode_top_bar_logo_full.png","logo_small":"gitbook-plugin-theme-dronecode/images/dronecode_top_bar_logo_small.png","url":"https://www.dronecode.org/"}},"validate-links":{"defaultScheme":"https","local":"warn","remote":"disabled"},"collapsible-menu":{},"language-picker":{"grid-columns":3},"youtube":{},"search":{},"mermaid":{},"lunr":{"maxIndexSize":1000000,"ignoreSpecialCharacters":false},"versions-select":{"type":"branches"},"fontsettings":{"theme":"white","family":"sans","size":2},"richquotes":{"tip":{"alert":"success","picto":"fa-thumbs-o-up"}},"highlight":{},"favicon":"favicon.ico","page-toc-button":{},"bulk-redirect":{"basepath":"/","redirectsFile":"redirects.json"},"custom-favicon":{},"mathjax":{"forceSVG":false,"version":"2.7.6"},"ga":{"configuration":"auto","token":"UA-33658859-3"},"versions":{"gitbookConfigURL":"https://raw.githubusercontent.com/PX4/Devguide/master/book.json","options":[{"value":"https://dev.px4.io/master/en/","text":"master"},{"value":"https://dev.px4.io/v1.10/en/","text":"1.10 - stable"},{"value":"https://dev.px4.io/v1.9.0/en/","text":"1.9 "},{"value":"https://dev.px4.io/v1.8.2/en/","text":"1.8.2"},{"value":"https://dev.px4.io/v1.8.0/en/","text":"1.8.0"}]},"toolbar":{"buttons":[{"label":"Bug tracker","icon":"fa fa-bug","position":"left","url":"https://github.com/PX4/Devguide/issues/new?title=Doc+Bug:+{{title}}&body=DESCRIBE+PROBLEM+WITH+DOCS+HERE%0A%0ABug+Page:+[{{title}}]({{url}})"},{"label":"GitHub","icon":"fa fa-github","url":"https://github.com/PX4/Devguide"},{"label":"Edit page on github","icon":"fa fa-pencil-square-o","position":"left","url":"https://github.com/PX4/Devguide/edit/master/{{filepath_lang}}"}]},"sharing":{"facebook":true,"twitter":true,"google":false,"weibo":false,"instapaper":false,"vk":false,"all":["facebook","google","twitter","weibo","instapaper"]},"theme-default":{"styles":{"website":"styles/website.css","pdf":"styles/pdf.css","epub":"styles/epub.css","mobi":"styles/mobi.css","ebook":"styles/ebook.css","print":"styles/print.css"},"showLevel":false},"anchors":{}},"theme":"default","pdf":{"pageNumbers":true,"fontSize":12,"fontFamily":"Arial","paperSize":"a4","chapterMark":"pagebreak","pageBreaksBefore":"/","margin":{"right":62,"left":62,"top":56,"bottom":56}},"structure":{"langs":"LANGS.md","readme":"README.md","glossary":"GLOSSARY.md","summary":"SUMMARY.md"},"variables":{"logo":"./assets/site/logo_pro_small.png","px4_version":"master"},"title":"PX4 Developer Guide","language":"en","gitbook":"*"},"file":{"path":"middleware/mavlink.md","mtime":"2020-04-08T16:15:12.438Z","type":"markdown"},"gitbook":{"version":"3.2.3","time":"2020-04-08T16:16:20.251Z"},"basePath":"..","book":{"language":"en"}});
         });
     </script>
 </div>


### PR DESCRIPTION
Added some small fixes and notes that help clarify building MAVLink libraries for the PX4 and QGroundControl.

- Noted issue with mavgen not correctly building nested includes
- An issue with inclusion checks breaking when using .../mavlink.h in common_messages.cpp
- Small tweaks to code snippets to reflect how they look in current code
- A couple small typo fixes