### PR TITLE
Creating a Fast RTPS Listener application Example updated

### DIFF
--- a/master/en/middleware/micrortps.html
+++ b/master/en/middleware/micrortps.html
@@ -2712,7 +2712,7 @@ For this example the <em>Agent</em> and <em>Listener application</em> will be on
 <pre><code class="lang-sh"><span class="hljs-built_in">cd</span> /path/to/PX4/Firmware/build/px4_sitl_rtps/src/modules/micrortps_bridge
 mkdir micrortps_listener
 <span class="hljs-built_in">cd</span> micrortps_listener
-fastrtpsgen -example x64Linux2.6gcc ../micrortps_client/micrortps_agent/idl/sensor_combined.idl
+fastrtpsgen -example x64Linux2.6gcc ../micrortps_client/micrortps_agent/idl/sensor_combined_.idl
 </code></pre>
 <p>This creates a basic subscriber and publisher, and a main-application to run them.
 To print out the data from the <code>sensor_combined</code> topic, modify the <code>onNewDataMessage()</code> method in <strong>sensor_combined_Subscriber.cxx</strong>:</p>
@@ -2730,23 +2730,16 @@ To print out the data from the <code>sensor_combined</code> topic, modify the <c
             <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;\n\n\n\n\n\n\n\n\n\n&quot;</span>;
             <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;Sample received, count=&quot;</span> &lt;&lt; n_msg &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
             <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;=============================&quot;</span> &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;gyro_rad: &quot;</span> &lt;&lt; st.gyro_rad().at(<span class="hljs-number">0</span>);
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;, &quot;</span> &lt;&lt; st.gyro_rad().at(<span class="hljs-number">1</span>);
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;, &quot;</span> &lt;&lt; st.gyro_rad().at(<span class="hljs-number">2</span>) &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;gyro_integral_dt: &quot;</span> &lt;&lt; st.gyro_integral_dt() &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
+            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;gyro_rad: &quot;</span> &lt;&lt; st.gyro_rad_().at(<span class="hljs-number">0</span>);
+            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;, &quot;</span> &lt;&lt; st.gyro_rad_().at(<span class="hljs-number">1</span>);
+            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;, &quot;</span> &lt;&lt; st.gyro_rad_().at(<span class="hljs-number">2</span>) &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
+            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;gyro_integral_dt: &quot;</span> &lt;&lt; st.gyro_integral_dt_() &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
             <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;accelerometer_timestamp_relative: &quot;</span> &lt;&lt; st.accelerometer_timestamp_relative() &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;accelerometer_m_s2: &quot;</span> &lt;&lt; st.accelerometer_m_s2().at(<span class="hljs-number">0</span>);
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;, &quot;</span> &lt;&lt; st.accelerometer_m_s2().at(<span class="hljs-number">1</span>);
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;, &quot;</span> &lt;&lt; st.accelerometer_m_s2().at(<span class="hljs-number">2</span>) &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;accelerometer_integral_dt: &quot;</span> &lt;&lt; st.accelerometer_integral_dt() &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;magnetometer_timestamp_relative: &quot;</span> &lt;&lt; st.magnetometer_timestamp_relative() &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;magnetometer_ga: &quot;</span> &lt;&lt; st.magnetometer_ga().at(<span class="hljs-number">0</span>);
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;, &quot;</span> &lt;&lt; st.magnetometer_ga().at(<span class="hljs-number">1</span>);
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;, &quot;</span> &lt;&lt; st.magnetometer_ga().at(<span class="hljs-number">2</span>) &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;baro_timestamp_relative: &quot;</span> &lt;&lt; st.baro_timestamp_relative() &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;baro_alt_meter: &quot;</span> &lt;&lt; st.baro_alt_meter() &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
-            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;baro_temp_celcius: &quot;</span> &lt;&lt; st.baro_temp_celcius() &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
-
+            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;accelerometer_m_s2: &quot;</span> &lt;&lt; st.accelerometer_m_s2_().at(<span class="hljs-number">0</span>);
+            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;, &quot;</span> &lt;&lt; st.accelerometer_m_s2_().at(<span class="hljs-number">1</span>);
+            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;, &quot;</span> &lt;&lt; st.accelerometer_m_s2_().at(<span class="hljs-number">2</span>) &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
+            <span class="hljs-built_in">std</span>::<span class="hljs-built_in">cout</span> &lt;&lt; <span class="hljs-string">&quot;accelerometer_integral_dt: &quot;</span> &lt;&lt; st.accelerometer_integral_dt_() &lt;&lt; <span class="hljs-built_in">std</span>::<span class="hljs-built_in">endl</span>;
+           
         }
     }
 }

--- a/master/en/middleware/micrortps.html
+++ b/master/en/middleware/micrortps.html
@@ -2757,11 +2757,6 @@ gyro_integral_dt: 0.004
 accelerometer_timestamp_relative: 0
 accelerometer_m_s2: -2.82708, -6.34799, -7.41101
 accelerometer_integral_dt: 0.004
-magnetometer_timestamp_relative: -10210
-magnetometer_ga: 0.60171, 0.0405879, -0.040995
-baro_timestamp_relative: -17469
-baro_alt_meter: 368.647
-baro_temp_celcius: 43.93
 </code></pre>
 <blockquote class="clearfix alert alert-info"><strong class="fa fa-2x fa-edit"></strong>
 <p> If the <em>Listener application</em> does not print anything, make sure the <em>Client</em> is running.</p>


### PR DESCRIPTION
Fixed example to reflect changes to the sensor_combined_ file and example code.  It does not include magnotometer and barometer in the functions and therefore code will not build.  As well as now functions have trailing _.